### PR TITLE
Adding safe configuration persistence.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN rm /etc/ssh/*_key /etc/ssh/*_key.pub
 ENV SSHD_CONFIG_SHA1SUM ad2a2b17ecde36c7ff9b0c55f925754e881bd1f5
 ADD templates/etc /etc
 ADD templates/bin /usr/bin
+ADD templates/.bash_logout /root
 
 VOLUME ["/home", "/etc-backup", "/etc/ssh/keys", "/sftp"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN chmod +s /usr/bin/sudo
 # Delete default host keys
 RUN rm /etc/ssh/*_key /etc/ssh/*_key.pub
 
+ENV SSHD_CONFIG_SHA1SUM ad2a2b17ecde36c7ff9b0c55f925754e881bd1f5
 ADD templates/etc /etc
 ADD templates/bin /usr/bin
 

--- a/run-database.sh
+++ b/run-database.sh
@@ -5,7 +5,7 @@ if [[ "$1" == "--initialize" ]]; then
   ssh-keygen -f /etc/ssh/keys/ssh_host_rsa_key -N '' -t rsa
   ssh-keygen -f /etc/ssh/keys/ssh_host_dsa_key -N '' -t dsa
   add-privileged-user $USERNAME $PASSPHRASE
-  cp /etc/{passwd,shadow,group} /etc-backup
+  backup-users
   exit
 fi
 

--- a/run-database.sh
+++ b/run-database.sh
@@ -13,17 +13,13 @@ function exit_gracefully {
 	kill -TERM "$SSH_PID"
 	sleep 2
 	backup-users
+	warn-sshd-config
 }
 
 trap exit_gracefully TERM INT
 
 cp /etc-backup/* /etc
 cp /etc-backup/ssh/* /etc/ssh/
-
-echo "$SSHD_CONFIG_SHA1SUM /etc/ssh/sshd_config" | sha1sum -c - \
-  || echo "WARNING: unexpected hash for /etc/ssh/sshd_config. "\
-           "This _may_ be malicious, or you may have intended to "\
-           "change this file."
 
 # Ensure that rsyslogd creates the socket
 rm -f /home/.sharedlogsocket

--- a/run-database.sh
+++ b/run-database.sh
@@ -4,10 +4,18 @@ if [[ "$1" == "--initialize" ]]; then
   ssh-keygen -f /etc/ssh/keys/ssh_host_ecdsa_key -N '' -t ecdsa
   ssh-keygen -f /etc/ssh/keys/ssh_host_rsa_key -N '' -t rsa
   ssh-keygen -f /etc/ssh/keys/ssh_host_dsa_key -N '' -t dsa
-  add-privileged-user $USERNAME $PASSPHRASE
-  backup-users
+  add-privileged-user "$USERNAME" "$PASSPHRASE"
   exit
 fi
+
+function exit_gracefully {
+	SSH_PID=$(cat /var/run/sshd.pid)
+	kill -TERM "$SSH_PID"
+	sleep 2
+	backup-users
+}
+
+trap exit_gracefully TERM INT
 
 cp /etc-backup/* /etc
 cp /etc-backup/ssh/* /etc/ssh/
@@ -28,4 +36,9 @@ set-access-log
 
 # Wait for /var/log/auth.log to exist, then tail it
 while [ ! -f /var/log/auth.log ] ; do sleep 0.1; done
-tail -f /var/log/auth.log
+tail -f /var/log/auth.log &
+
+# We would prefer to wait on the sshd PID, but it's not a subprocess of this shell.
+
+TAIL_PID="$!"
+wait "$TAIL_PID"

--- a/run-database.sh
+++ b/run-database.sh
@@ -10,6 +10,12 @@ if [[ "$1" == "--initialize" ]]; then
 fi
 
 cp /etc-backup/* /etc
+cp /etc-backup/ssh/* /etc/ssh/
+
+echo "$SSHD_CONFIG_SHA1SUM /etc/ssh/sshd_config" | sha1sum -c - \
+  || echo "WARNING: unexpected hash for /etc/ssh/sshd_config. "\
+           "This _may_ be malicious, or you may have intended to "\
+           "change this file."
 
 # Ensure that rsyslogd creates the socket
 rm -f /home/.sharedlogsocket

--- a/templates/.bash_logout
+++ b/templates/.bash_logout
@@ -8,5 +8,7 @@ fi
 
 
 if ! diff /etc/passwd /etc-backup/passwd &> /dev/null; then
-  echo "WARNING - you edited users without backing up the configuration."
+  echo "WARNING - you edited users without backing up the configuration.\
+  We will attempt to persist these at container exit, but you may run the command\
+  backup-users at any time to do so manually."
 fi

--- a/templates/.bash_logout
+++ b/templates/.bash_logout
@@ -7,10 +7,6 @@ if [ "$SHLVL" = 1 ]; then
 fi
 
 
-if ! diff /etc/passwd /etc-backup/passwd &> /dev/null; then
-  echo "WARNING - you edited users without backing up the configuration. "\
-       "We will attempt to persist these at container exit, but you may run "
-       "the command backup-users at any time to do so manually."
-fi
+backup-users
 
 warn-sshd-config

--- a/templates/.bash_logout
+++ b/templates/.bash_logout
@@ -1,0 +1,12 @@
+# ~/.bash_logout: executed by bash(1) when login shell exits.
+
+# when leaving the console clear the screen to increase privacy
+
+if [ "$SHLVL" = 1 ]; then
+    [ -x /usr/bin/clear_console ] && /usr/bin/clear_console -q
+fi
+
+
+if ! diff /etc/passwd /etc-backup/passwd &> /dev/null; then
+  echo "WARNING - you edited users without backing up the configuration."
+fi

--- a/templates/.bash_logout
+++ b/templates/.bash_logout
@@ -8,7 +8,9 @@ fi
 
 
 if ! diff /etc/passwd /etc-backup/passwd &> /dev/null; then
-  echo "WARNING - you edited users without backing up the configuration.\
-  We will attempt to persist these at container exit, but you may run the command\
-  backup-users at any time to do so manually."
+  echo "WARNING - you edited users without backing up the configuration. "\
+       "We will attempt to persist these at container exit, but you may run "
+       "the command backup-users at any time to do so manually."
 fi
+
+warn-sshd-config

--- a/templates/bin/add-privileged-user
+++ b/templates/bin/add-privileged-user
@@ -18,3 +18,5 @@ usermod -G $user,sudo $user
 usermod -s /bin/bash $user
 usermod -d /home/$user $user
 echo $user:$password | chpasswd
+
+backup-users

--- a/templates/bin/add-privileged-user
+++ b/templates/bin/add-privileged-user
@@ -19,4 +19,6 @@ usermod -s /bin/bash $user
 usermod -d /home/$user $user
 echo $user:$password | chpasswd
 
+cp /root/.bash_logout /home/$user/
+
 backup-users

--- a/templates/bin/add-sftp-user
+++ b/templates/bin/add-sftp-user
@@ -31,3 +31,5 @@ chown -R "$user":"$user" "/home/$user/.ssh"
 chmod -R go-rx "/home/$user/.ssh"
 
 /usr/bin/set-access-log "$user"
+
+backup-users

--- a/templates/bin/backup-users
+++ b/templates/bin/backup-users
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cp /etc/{passwd,shadow,group} /etc-backup

--- a/templates/bin/warn-sshd-config
+++ b/templates/bin/warn-sshd-config
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+diff /etc-backup/ssh/sshd_config /etc/ssh/sshd_config > /dev/null 2>&1
+diff_result="$?"
+
+echo "$SSHD_CONFIG_SHA1SUM /etc/ssh/sshd_config" | sha1sum -c - > /dev/null 2>&1
+hash_result="$?"
+
+if [ "$hash_result" -ne 0 ] && [ "$diff_result" -ne 0 ] ; then
+  echo "WARNING - changes detected in /etc/ssh/sshd_config. These changes "\
+    "will not be persisted after restart. If you wish for these changes to "\
+    "persist next restart, copy the sshd_config file to /etc-backup/sshd/"
+fi

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$1"
+
+DB_CONTAINER="sftp"
+DATA_CONTAINER="${DB_CONTAINER}-data"
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$DB_CONTAINER" "$DATA_CONTAINER" >/dev/null 2>&1 || true
+}
+
+function wait_for_db {
+  for _ in $(seq 1 100); do
+    if docker exec -it "$DB_CONTAINER" pgrep tail >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  echo "DB never came online"
+  docker logs "$DB_CONTAINER"
+  return 1
+}
+
+trap cleanup EXIT
+cleanup
+
+echo "Creating data container"
+docker create --name "$DATA_CONTAINER" "$IMG"
+
+echo "Starting DB"
+docker run -it --rm \
+  -e USERNAME=user -e PASSPHRASE=pass \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" --initialize \
+  >/dev/null 2>&1
+
+docker run -d --rm --name="$DB_CONTAINER" \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" >/dev/null 2>&1
+
+echo "Waiting for DB to come online"
+wait_for_db
+
+echo "Creating user and intentionally persisting."
+docker exec -it "$DB_CONTAINER" add-sftp-user foo fee
+docker exec -it "$DB_CONTAINER" cp /etc/{passwd,shadow,group} /etc-backup
+
+echo "Creating ephemeral user."
+docker exec -it "$DB_CONTAINER" add-sftp-user bar bee
+
+docker exec -it "$DB_CONTAINER" id foo >/dev/null 2>&1
+docker exec -it "$DB_CONTAINER" id bar >/dev/null 2>&1
+
+echo "Stopping DB"
+docker stop "$DB_CONTAINER"
+
+echo "Starting DB"
+docker run -d --rm --name="$DB_CONTAINER" \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" >/dev/null 2>&1
+
+
+echo "Checking the persistent user does exist."
+docker exec -it "$DB_CONTAINER" id foo >/dev/null 2>&1
+
+echo "Checking the ephemeral user does not exist."
+! docker exec -it "$DB_CONTAINER" id bar >/dev/null 2>&1

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -45,8 +45,6 @@ docker run -d --name="$DB_CONTAINER" \
 echo "Waiting for DB to come online"
 wait_for_db
 
-docker exec "$DB_CONTAINER" mkdir /etc-backup/ssh
-
 echo "Creating additional users."
 docker exec "$DB_CONTAINER" add-sftp-user foo fee
 docker exec "$DB_CONTAINER" useradd bar
@@ -54,28 +52,39 @@ docker exec "$DB_CONTAINER" useradd bar
 echo "Modify the sshd config."
 docker exec "$DB_CONTAINER" bash -c "echo '#foobar' >> /etc/ssh/sshd_config"
 
-echo "Persist the sshd config."
-docker exec "$DB_CONTAINER" cp /etc/ssh/sshd_config /etc-backup/ssh/
-
 echo "Stopping DB"
 docker stop "$DB_CONTAINER" >/dev/null 2>&1
 
 echo "Check that SSHD was terminated."
 docker logs "$DB_CONTAINER" | grep "Received signal 15; terminating." >/dev/null 2>&1
 
+echo "Esnure we got warned that an sshd_config was modified"
+docker logs "$DB_CONTAINER" | grep 'WARNING - changes detected in /etc/ssh/sshd_config' >/dev/null 2>&1
+
 echo "Simulate deploy restart (volume persists, container recycled)"
 docker rm "$DB_CONTAINER" >/dev/null
-docker run -d --rm --name="$DB_CONTAINER" \
+docker run -d --name="$DB_CONTAINER" \
   --volumes-from "$DATA_CONTAINER" \
   "$IMG" >/dev/null 2>&1
-
 
 echo "Checking the additional users do exist."
 docker exec "$DB_CONTAINER" id foo >/dev/null 2>&1
 docker exec "$DB_CONTAINER" id bar >/dev/null 2>&1
 
-echo "Ensure the sshd file is not still modified"
-docker exec "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config >/dev/null 2>&1
+echo "Check the sshd_config modifications were lost."
+! docker exec "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config >/dev/null 2>&1
 
-echo "Esnure we got warned that an un-expected sshd_config file was used"
-docker logs "$DB_CONTAINER" | grep 'WARNING: unexpected' >/dev/null 2>&1
+echo "Modify and persist the sshd_config."
+docker exec "$DB_CONTAINER" mkdir /etc-backup/ssh
+docker exec "$DB_CONTAINER" bash -c "echo '#foobar' >> /etc/ssh/sshd_config"
+docker exec "$DB_CONTAINER" cp /etc/ssh/sshd_config /etc-backup/ssh/
+
+echo "Simulate deploy restart (volume persists, container recycled)"
+docker stop "$DB_CONTAINER" >/dev/null 2>&1
+docker rm "$DB_CONTAINER" >/dev/null
+docker run -d --rm --name="$DB_CONTAINER" \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" >/dev/null 2>&1
+
+echo "Ensure the sshd file is still modified"
+docker exec "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config >/dev/null 2>&1

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -52,12 +52,8 @@ docker exec -it "$DB_CONTAINER" cp /etc/{passwd,shadow,group} /etc-backup
 echo "Creating ephemeral user."
 docker exec -it "$DB_CONTAINER" add-sftp-user bar bee
 
-docker exec -it "$DB_CONTAINER" id foo >/dev/null 2>&1
-docker exec -it "$DB_CONTAINER" id bar >/dev/null 2>&1
-
 echo "Modify the sshd config."
 docker exec -it "$DB_CONTAINER" bash -c "echo '#foobar' >> /etc/ssh/sshd_config"
-docker exec -it "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config
 
 echo "Persist the sshd config."
 docker exec -it "$DB_CONTAINER" mkdir /etc-backup/ssh
@@ -82,4 +78,4 @@ echo "Ensure the sshd file is not still modified"
 docker exec -it "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config >/dev/null 2>&1
 
 echo "Esnure we got warned that an un-expected sshd_config file was used"
-docker logs "$DB_CONTAINER" | grep 'WARNING: unexpected'
+docker logs "$DB_CONTAINER" | grep 'WARNING: unexpected' >/dev/null 2>&1

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -45,12 +45,8 @@ docker run -d --rm --name="$DB_CONTAINER" \
 echo "Waiting for DB to come online"
 wait_for_db
 
-echo "Creating user and intentionally persisting."
+echo "Creating additional user."
 docker exec -it "$DB_CONTAINER" add-sftp-user foo fee
-docker exec -it "$DB_CONTAINER" cp /etc/{passwd,shadow,group} /etc-backup
-
-echo "Creating ephemeral user."
-docker exec -it "$DB_CONTAINER" add-sftp-user bar bee
 
 echo "Modify the sshd config."
 docker exec -it "$DB_CONTAINER" bash -c "echo '#foobar' >> /etc/ssh/sshd_config"
@@ -68,11 +64,8 @@ docker run -d --rm --name="$DB_CONTAINER" \
   "$IMG" >/dev/null 2>&1
 
 
-echo "Checking the persistent user does exist."
+echo "Checking the additional users do exist."
 docker exec -it "$DB_CONTAINER" id foo >/dev/null 2>&1
-
-echo "Checking the ephemeral user does not exist."
-! docker exec -it "$DB_CONTAINER" id bar >/dev/null 2>&1
 
 echo "Ensure the sshd file is not still modified"
 docker exec -it "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config >/dev/null 2>&1

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -38,37 +38,44 @@ docker run -it --rm \
   "$IMG" --initialize \
   >/dev/null 2>&1
 
-docker run -d --rm --name="$DB_CONTAINER" \
+docker run -d --name="$DB_CONTAINER" \
   --volumes-from "$DATA_CONTAINER" \
   "$IMG" >/dev/null 2>&1
 
 echo "Waiting for DB to come online"
 wait_for_db
 
-echo "Creating additional user."
-docker exec -it "$DB_CONTAINER" add-sftp-user foo fee
+docker exec "$DB_CONTAINER" mkdir /etc-backup/ssh
+
+echo "Creating additional users."
+docker exec "$DB_CONTAINER" add-sftp-user foo fee
+docker exec "$DB_CONTAINER" useradd bar
 
 echo "Modify the sshd config."
-docker exec -it "$DB_CONTAINER" bash -c "echo '#foobar' >> /etc/ssh/sshd_config"
+docker exec "$DB_CONTAINER" bash -c "echo '#foobar' >> /etc/ssh/sshd_config"
 
 echo "Persist the sshd config."
-docker exec -it "$DB_CONTAINER" mkdir /etc-backup/ssh
-docker exec -it "$DB_CONTAINER" cp /etc/ssh/sshd_config /etc-backup/ssh/
+docker exec "$DB_CONTAINER" cp /etc/ssh/sshd_config /etc-backup/ssh/
 
 echo "Stopping DB"
-docker stop "$DB_CONTAINER"
+docker stop "$DB_CONTAINER" >/dev/null 2>&1
 
-echo "Starting DB"
+echo "Check that SSHD was terminated."
+docker logs "$DB_CONTAINER" | grep "Received signal 15; terminating." >/dev/null 2>&1
+
+echo "Simulate deploy restart (volume persists, container recycled)"
+docker rm "$DB_CONTAINER" >/dev/null
 docker run -d --rm --name="$DB_CONTAINER" \
   --volumes-from "$DATA_CONTAINER" \
   "$IMG" >/dev/null 2>&1
 
 
 echo "Checking the additional users do exist."
-docker exec -it "$DB_CONTAINER" id foo >/dev/null 2>&1
+docker exec "$DB_CONTAINER" id foo >/dev/null 2>&1
+docker exec "$DB_CONTAINER" id bar >/dev/null 2>&1
 
 echo "Ensure the sshd file is not still modified"
-docker exec -it "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config >/dev/null 2>&1
+docker exec "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config >/dev/null 2>&1
 
 echo "Esnure we got warned that an un-expected sshd_config file was used"
 docker logs "$DB_CONTAINER" | grep 'WARNING: unexpected' >/dev/null 2>&1

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -59,6 +59,10 @@ echo "Modify the sshd config."
 docker exec -it "$DB_CONTAINER" bash -c "echo '#foobar' >> /etc/ssh/sshd_config"
 docker exec -it "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config
 
+echo "Persist the sshd config."
+docker exec -it "$DB_CONTAINER" mkdir /etc-backup/ssh
+docker exec -it "$DB_CONTAINER" cp /etc/ssh/sshd_config /etc-backup/ssh/
+
 echo "Stopping DB"
 docker stop "$DB_CONTAINER"
 
@@ -75,4 +79,7 @@ echo "Checking the ephemeral user does not exist."
 ! docker exec -it "$DB_CONTAINER" id bar >/dev/null 2>&1
 
 echo "Ensure the sshd file is not still modified"
-! docker exec -it "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config >/dev/null 2>&1
+docker exec -it "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config >/dev/null 2>&1
+
+echo "Esnure we got warned that an un-expected sshd_config file was used"
+docker logs "$DB_CONTAINER" | grep 'WARNING: unexpected'

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -55,6 +55,10 @@ docker exec -it "$DB_CONTAINER" add-sftp-user bar bee
 docker exec -it "$DB_CONTAINER" id foo >/dev/null 2>&1
 docker exec -it "$DB_CONTAINER" id bar >/dev/null 2>&1
 
+echo "Modify the sshd config."
+docker exec -it "$DB_CONTAINER" bash -c "echo '#foobar' >> /etc/ssh/sshd_config"
+docker exec -it "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config
+
 echo "Stopping DB"
 docker stop "$DB_CONTAINER"
 
@@ -69,3 +73,6 @@ docker exec -it "$DB_CONTAINER" id foo >/dev/null 2>&1
 
 echo "Checking the ephemeral user does not exist."
 ! docker exec -it "$DB_CONTAINER" id bar >/dev/null 2>&1
+
+echo "Ensure the sshd file is not still modified"
+! docker exec -it "$DB_CONTAINER" grep "foobar" /etc/ssh/sshd_config >/dev/null 2>&1

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$REGISTRY/$REPOSITORY:$TAG"
+
+
+TESTS=(
+	test-restart
+)
+
+for t in "${TESTS[@]}"; do
+  echo "--- START ${t} ---"
+  "./${t}.sh" "$IMG"
+  echo "--- OK    ${t} ---"
+  echo
+done
+
+echo "#############"
+echo "# Tests OK! #"
+echo "#############"

--- a/test/sftp.bats
+++ b/test/sftp.bats
@@ -143,3 +143,7 @@ EOF
 @test "It should disable RepeatedMsgReduction in rsyslog" {
   grep -r "RepeatedMsgReduction off" /etc/rsyslog.d/
 }
+
+@test "The SHA1 sum of the sshd_config file is correct." {
+  echo "$SSHD_CONFIG_SHA1SUM /etc/ssh/sshd_config" | sha1sum -c -
+}


### PR DESCRIPTION
Catch signals so that we can gracefully stop the container.

Persist user and group files (copy to /etc-backup):
* when add-privileged-user is called
* when add-sftp-user is called
* when a privileged user logs out (eg after they edited the files without the above scripts)
* when the container gets signaled to exit

Warn if the sshd_config is modified, but not copied to /etc-backup/ssh/:
* when a privileged user logs out
* when the container exits

Test script added to cover behavior during restart.