### PR TITLE
Update to Ubuntu 16.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM quay.io/aptible/ubuntu:14.04
+FROM quay.io/aptible/ubuntu:16.04
+
+ENV SUDO_MIN 1.8.16-0ubuntu1.10
 
 RUN apt-get update
-RUN apt-get -y install openssh-server rssh sudo
+RUN apt-get -y install openssh-server rssh sudo rsyslog
 RUN mkdir -p /var/run/sshd
 RUN groupadd sftpusers
 RUN chmod +s /usr/bin/sudo

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For example, given the admin user `aptible`, one might run:
 
 ## Available Tags
 
-* `latest`: Currently OpenSSH 6.6.1p1
+* `latest`: Currently OpenSSH 7.2p2
 
 ## Tests
 

--- a/run-database.sh
+++ b/run-database.sh
@@ -23,6 +23,8 @@ cp /etc-backup/ssh/* /etc/ssh/
 
 # Ensure that rsyslogd creates the socket
 rm -f /home/.sharedlogsocket
+# Ensure /var/log is owned by the syslog group, since the GID changed
+chgrp syslog /var/log
 rsyslogd
 /usr/sbin/sshd
 

--- a/test/sftp.bats
+++ b/test/sftp.bats
@@ -27,7 +27,7 @@ wait_for_sftp() {
 
 @test "It should install sshd " {
   run /usr/sbin/sshd -v
-  [[ "$output" =~ "OpenSSH_6.6.1p1" ]]
+  [[ "$output" =~ "OpenSSH_7.2p2" ]]
 }
 
 @test "It should create an admin account" {

--- a/test/sudo.bats
+++ b/test/sudo.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+# https://ubuntu.com/security/CVE-2021-3156
+
+@test "It should install a sudo version protected from CVE-2021-3156" {
+  actual_version="$(dpkg-query --showformat='${Version}' --show sudo)"
+  echo "Installed sudo: $actual_version"
+  echo "Desired sudo:   $SUDO_MIN"
+  dpkg --compare-versions "$actual_version" "ge" "$SUDO_MIN"
+}


### PR DESCRIPTION
Update to Ubuntu 16.
Ensure `sudo` is safe from https://nvd.nist.gov/vuln/detail/CVE-2021-3156
Ensure ownership of /var/log is correct, given the GID changed in the ubuntu update.